### PR TITLE
Allow changing names

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     }
   },
   "types": "./dist/y-textArea.d.ts",
-  "version": "0.2.4",
+  "version": "0.2.6",
   "scripts": {
     "dev": "vite --host",
     "build": "tsc && vite build",

--- a/src/y-textArea-Cursors.ts
+++ b/src/y-textArea-Cursors.ts
@@ -22,6 +22,7 @@ class Cursor{
     private _color : color;
     private _fontSize : string;
     private _selectedIndex : {start:number, end:number};
+    private _name? : string;
 
     private _parent : Element;
 
@@ -29,6 +30,7 @@ class Cursor{
         this._selectedIndex = {start:-1, end:-1};
         this._fontSize = fontSize;
         this._color = cssColor;
+        this._name = name;
         this._parent = element.offsetParent || document.body;
         this._div = document.createElement('div')
         this._div.style.position = 'absolute'
@@ -60,6 +62,24 @@ class Cursor{
         this._div.style.display = 'none';
         if(this._nameDiv)
             this._nameDiv.style.display = 'none';
+    }
+
+    setName(name: string) {
+        // Don't update DOM if name is the same
+        if (this._name === name) return;
+
+        this._name = name;
+        if (this._nameDiv) {
+            this._nameDiv.innerHTML = name;
+            return;
+        }
+        this._nameDiv = document.createElement('div')
+        this._nameDiv.style.position = 'absolute';
+        this._nameDiv.style.display = 'none';
+        this._nameDiv.style.backgroundColor = `rgba(${this._color.r}, ${this._color.g}, ${this._color.b}, 1.0)`
+        this._nameDiv.classList.add("nameTag");
+        this._nameDiv.innerHTML = name;
+        this._parent.appendChild(this._nameDiv);
     }
 
     setPosition(start : number, end: number) {
@@ -200,6 +220,8 @@ export class TextAreaCursors {
                     ));
                 }
                 const cursorMarker = this._cursors.get(clientID);
+
+                cursorMarker?.setName(name);
 
                 if(!selection) {
                     cursorMarker?.setPosition(-1,-1);


### PR DESCRIPTION
First off, just wanted to say thanks for this great lib!

This PR makes it so that the cursor user names update if they change on the other side. If `clientName` on the options object changes at client A, it will update the name on client B. My use case is to allow users to change their name in a separate text input during editing, not before.

This was already half-possible. If client B joined after client A changed their name, it would be reflected. But if client B joined before client A changed their name, they wouldn't see the change. The missing piece was that old cursors don't get updated as the name is copied [here](https://github.com/cm226/y-textarea/blob/8384e5390b26bac8a4fc3a4ef00eb9f63995d320/src/y-textArea-Cursors.ts#L45).

So this PR fixes that, and I bumped the version too. Hope this is worth merging!