### PR TITLE
Fix textfieldChange value when multiple changes locally

### DIFF
--- a/src/y-textArea.ts
+++ b/src/y-textArea.ts
@@ -80,7 +80,6 @@ export class TextAreaBinding {
     const onTextFieldInput = () => {
       textfieldChanged = true
       const r = this.createRange(textField)
-      textfieldChanged = true
       let oldContent = yText.toString()
       let content = textField.value
       let diffs = diff(oldContent, content, r.left)

--- a/src/y-textArea.ts
+++ b/src/y-textArea.ts
@@ -79,26 +79,27 @@ export class TextAreaBinding {
 
     const onTextFieldInput = () => {
       const r = this.createRange(textField)
+      textfieldChanged = true
       let oldContent = yText.toString()
       let content = textField.value
       let diffs = diff(oldContent, content, r.left)
       let pos = 0
-      for (let i = 0; i < diffs.length; i++) {
-        let d = diffs[i]
-        if (d[0] === 0) {
-          // EQUAL
-          pos += d[1].length
-        } else if (d[0] === -1) {
-          // DELETE
-          textfieldChanged = true
-          yText.delete(pos, d[1].length)
-        } else {
-          // INSERT
-          textfieldChanged = true
-          yText.insert(pos, d[1])
-          pos += d[1].length
+      doc.transact(tr => {
+        for (let i = 0; i < diffs.length; i++) {
+          let d = diffs[i]
+          if (d[0] === 0) {
+            // EQUAL
+            pos += d[1].length
+          } else if (d[0] === -1) {
+            // DELETE
+            yText.delete(pos, d[1].length)
+          } else {
+            // INSERT
+            yText.insert(pos, d[1])
+            pos += d[1].length
+          }
         }
-      }
+      })
     }
     textField.addEventListener('input', onTextFieldInput)
     this._unobserveFns.push(() =>

--- a/src/y-textArea.ts
+++ b/src/y-textArea.ts
@@ -78,9 +78,7 @@ export class TextAreaBinding {
     this._unobserveFns.push(() => yText.unobserve(yTextObserver))
 
     const onTextFieldInput = () => {
-      textfieldChanged = true
       const r = this.createRange(textField)
-
       let oldContent = yText.toString()
       let content = textField.value
       let diffs = diff(oldContent, content, r.left)
@@ -92,9 +90,11 @@ export class TextAreaBinding {
           pos += d[1].length
         } else if (d[0] === -1) {
           // DELETE
+          textfieldChanged = true
           yText.delete(pos, d[1].length)
         } else {
           // INSERT
+          textfieldChanged = true
           yText.insert(pos, d[1])
           pos += d[1].length
         }

--- a/src/y-textArea.ts
+++ b/src/y-textArea.ts
@@ -78,27 +78,28 @@ export class TextAreaBinding {
     this._unobserveFns.push(() => yText.unobserve(yTextObserver))
 
     const onTextFieldInput = () => {
+      textfieldChanged = true
       const r = this.createRange(textField)
       let oldContent = yText.toString()
       let content = textField.value
       let diffs = diff(oldContent, content, r.left)
       let pos = 0
-      for (let i = 0; i < diffs.length; i++) {
-        let d = diffs[i]
-        if (d[0] === 0) {
-          // EQUAL
-          pos += d[1].length
-        } else if (d[0] === -1) {
-          // DELETE
-          textfieldChanged = true
-          yText.delete(pos, d[1].length)
-        } else {
-          // INSERT
-          textfieldChanged = true
-          yText.insert(pos, d[1])
-          pos += d[1].length
+      doc.transact(tr => {
+        for (let i = 0; i < diffs.length; i++) {
+          let d = diffs[i]
+          if (d[0] === 0) {
+            // EQUAL
+            pos += d[1].length
+          } else if (d[0] === -1) {
+            // DELETE
+            yText.delete(pos, d[1].length)
+          } else {
+            // INSERT
+            yText.insert(pos, d[1])
+            pos += d[1].length
+          }
         }
-      }
+      })
     }
     textField.addEventListener('input', onTextFieldInput)
     this._unobserveFns.push(() =>


### PR DESCRIPTION
Move `textfieldChanged = true` so that it stays true when `diffs` contained multiple delete / insert. Without this, textfieldChanged is true only for the first edit, as it is put back to false after `yText` modification.

This fix issues when selecting text and replacing it with something else, which ended up in a cursor shift before.